### PR TITLE
Fix infinite loop in gmp_float to fixed-point string conversion

### DIFF
--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -306,6 +306,7 @@ struct gmp_float_imp
                         round_up = true;
                         break;
                      }
+                     ++i;
                   }
                   if(round_up)
                   {


### PR DESCRIPTION
You can trigger the infinite loop with: 
```cpp
cout << setprecision(1) << fixed << mpf_float_50("0.0501");
```